### PR TITLE
Bug 1259058 - Modified s_mp_rshd()

### DIFF
--- a/lib/freebl/mpi/mpi.c
+++ b/lib/freebl/mpi/mpi.c
@@ -2978,8 +2978,7 @@ s_mp_rshd(mp_int *mp, mp_size p)
 
     MP_USED(mp) -= p;
     /* Fill the top digits with zeroes */
-    while (p-- > 0)
-        *dst++ = 0;
+    s_mp_setz(MP_DIGITS(mp) + MP_USED(mp), p);
 
 } /* end s_mp_rshd() */
 


### PR DESCRIPTION
Used s_mp_setz() to fill the top digits with zeroes after shifting in s_mp_rshd()