### PR TITLE
Subject: [PATCH] Fix SHA_HTONL bug for arm 32be.

### DIFF
--- a/lib/freebl/sha_fast.h
+++ b/lib/freebl/sha_fast.h
@@ -99,6 +99,7 @@ swap4b(PRUint32 value)
       defined(__ARM_ARCH_7__) ||   \
       defined(__ARM_ARCH_7A__) ||  \
       defined(__ARM_ARCH_7R__)))
+#if defined(IS_LITTLE_ENDIAN)
 static __inline__ PRUint32
 swap4b(PRUint32 value)
 {
@@ -109,6 +110,7 @@ swap4b(PRUint32 value)
     return ret;
 }
 #define SHA_HTONL(x) swap4b(x)
+#endif
 
 #endif /* x86 family */
 


### PR DESCRIPTION
Rpm use nss as digest crypto library and which will cause an error on
arm 32be platform as follows:

error: test-manual-1.2.3-20181012.noarch.rpm: Header SHA1 digest: BAD
(Expected
f1deb7dc4a10742d88ccd1e967dbc62ae45095a5
!=4ad9d7dad6d70d6086eefec62612ad5d77f2fe81)  => this value is wrong
error: test-manual-1.2.3-20181012.noarch.rpm: not an rpm package (or
package manifest)

The error is caused by SHA_HTONL in nss, for there is no need to reverse
the host value for arm 32be as it is originally big endian, so fix it.

Signed-off-by: Zheng Ruoqin <zhengrq.fnst@cn.fujitsu.com>