### PR TITLE
lib/freebl/genload.c: drop call to PR_SetError

### DIFF
--- a/lib/freebl/genload.c
+++ b/lib/freebl/genload.c
@@ -43,7 +43,7 @@ loader_GetOriginalPathname(const char* link)
     PRUint32 iterations = 0;
     PRInt32 len = 0, retlen = 0;
     if (!link) {
-        PR_SetError(PR_INVALID_ARGUMENT_ERROR, 0);
+        /*PR_SetError(PR_INVALID_ARGUMENT_ERROR, 0); */
         return NULL;
     }
     len = PR_MAX(1024, strlen(link) + 1);


### PR DESCRIPTION
Drop call to `PR_SetError` in `genload.c` as already done in `lowhash_vector.c` to avoid adding a dependency on a function defined in nspr and raising the following build failure when `FREEBL_NO_DEPEND` is set to 1 (default on Linux):

```
/home/buildroot/autobuild/instance-3/output-1/host/bin/microblazeel-linux-gcc -shared   -Wl,-z,defs -Wl,-soname -Wl,libfreebl3.so  -Wl,--version-script,Linux2.6_microblazeel_microblazeel-linux-gcc.br_real_glibc_PTH_DBG.OBJ/Linux_SINGLE_SHLIB/freebl.def -Wl,-Bsymbolic -o Linux2.6_microblazeel_microblazeel-linux-gcc.br_real_glibc_PTH_DBG.OBJ/Linux_SINGLE_SHLIB/libfreebl3.so Linux2.6_microblazeel_microblazeel-linux-gcc.br_real_glibc_PTH_DBG.OBJ/Linux_SINGLE_SHLIB/lowhash_vector.o      -ldl -lc
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/microblazeel-buildroot-linux-musl/11.2.0/../../../../microblazeel-buildroot-linux-musl/bin/ld: Linux2.6_microblazeel_microblazeel-linux-gcc.br_real_glibc_PTH_DBG.OBJ/Linux_SINGLE_SHLIB/lowhash_vector.o: in function `loader_GetOriginalPathname':
(.text.loader_GetOriginalPathname+0x1c4): undefined reference to `PR_SetError'
```

Fixes:
 - http://autobuild.buildroot.org/results/d00d22f1bfee5c175f3266ff16124632906463c3