### PR TITLE
Corrected ASN.1 syntax of DH key export template

### DIFF
--- a/lib/pk11wrap/pk11pk12.c
+++ b/lib/pk11wrap/pk11pk12.c
@@ -150,9 +150,11 @@ const SEC_ASN1Template SECKEY_DSAPrivateKeyExportTemplate[] = {
 };
 
 const SEC_ASN1Template SECKEY_DHPrivateKeyExportTemplate[] = {
+    { SEC_ASN1_SEQUENCE, 0, NULL, sizeof(SECKEYRawPrivateKey) },
     { SEC_ASN1_INTEGER, offsetof(SECKEYRawPrivateKey, u.dh.privateValue) },
     { SEC_ASN1_INTEGER, offsetof(SECKEYRawPrivateKey, u.dh.base) },
     { SEC_ASN1_INTEGER, offsetof(SECKEYRawPrivateKey, u.dh.prime) },
+    { 0 }
 };
 
 SEC_ASN1_MKSUB(SEC_BitStringTemplate)


### PR DESCRIPTION
The ASN1Template structure array for DH private keys was an array, however missing the leading SEC_ASN1_SEQUENCE entry.
Without this change no DH private keys are importable because only the privateValue is decoded, the base and prime are ignored.