### PR TITLE
Update contact email

### DIFF
--- a/cmd/modutil/modutil.c
+++ b/cmd/modutil/modutil.c
@@ -751,7 +751,7 @@ usage()
                "\n"
                "Cipher lists are colon-separated.  The following ciphers are recognized:\n"
                "\n"
-               "\nQuestions or bug reports should be sent to modutil-support@netscape.com.\n");
+               "\nQuestions or bug reports should be sent to dev-tech-crypto@mozilla.org.\n");
 }
 
 /*************************************************************************

--- a/cmd/ssltap/ssltap-manual.html
+++ b/cmd/ssltap/ssltap-manual.html
@@ -110,7 +110,7 @@ trying to connect to is different to the certificate, but it will still
 let you connect, after showing you a dialog.
 <H3>
 Bugs</H3>
-Please contact <A HREF="mailto:ssltap-support@netscape.com">ssltap-support@netscape.com</A>
+Please contact <A HREF="mailto:dev-tech-crypto@mozilla.org">dev-tech-crypto@mozilla.org</A>
 for bug reports.
 <H3>
 History</H3>

--- a/tests/doc/qa_wrapper.html
+++ b/tests/doc/qa_wrapper.html
@@ -20,7 +20,7 @@ tests are being run are called from the QA script all.sh. I will add documentati
 for the actual QA soon. The main purpose of the wrapper is: find out which
 build (NSS version, date, Build Platform) to test on which machine (OS,
 OS version) and construct a summary report, which is then mailed to the
-nss developers (aka mailing list nss-qa-report@netscape.com). Please see
+nss developers (aka mailing list dev-tech-crypto@mozilla.org). Please see
 also the <a href="#advertisement">feature</a> section.
 <p><a href="#nssqa">nssqa</a>&nbsp; - the script that calls the actual
 qa script all.sh


### PR DESCRIPTION
Very small PR, I noticed that the contact email was still set to a @netscape.com address

As these emails are not mentionned on https://firefox-source-docs.mozilla.org/security/nss/community.html#mozilla-projects-nss-community, and the netscape.com domain seems unused, I updated them to the mail of the dev-tech-crypto mailing list.

Feel free to close this PR if the change is more complicated than I though, I only submitted it because it took 5 mins to change 