### PR TITLE
lib/softtoken/{sdb.c,sftkdbti.h}: Align sftkdb_known_attributes_size type

### DIFF
--- a/lib/softoken/sdb.c
+++ b/lib/softoken/sdb.c
@@ -158,7 +158,7 @@ const CK_ATTRIBUTE_TYPE sftkdb_known_attributes[] = {
 };
 // clang-format on
 
-const int sftkdb_known_attributes_size = PR_ARRAY_SIZE(sftkdb_known_attributes);
+const size_t sftkdb_known_attributes_size = PR_ARRAY_SIZE(sftkdb_known_attributes);
 
 /*
  * Note on use of sqlReadDB: Only one thread at a time may have an actual

--- a/lib/softoken/sftkdbti.h
+++ b/lib/softoken/sftkdbti.h
@@ -27,7 +27,7 @@ struct SFTKDBHandleStr {
 };
 
 extern const CK_ATTRIBUTE_TYPE sftkdb_known_attributes[];
-extern unsigned int sftkdb_known_attributes_size;
+extern size_t sftkdb_known_attributes_size;
 
 #define SFTK_KEYDB_TYPE 0x40000000
 #define SFTK_CERTDB_TYPE 0x00000000


### PR DESCRIPTION
sftkdb_known_attributes_size is defined with conflicting types. In /lib/softtoken/sdb.c it is defined as a 'const size_t'; whereas in lib/softtoken/sftkdbti.h it is defined as an 'unsigned int'. The correct type for sftkdb_known_attributes_size is size_t since its value is derived from the size of the sftkdb_known_attributes array.

Fixes: 1983399